### PR TITLE
Add travis ci file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: node_js
+
+os:
+  - linux
+#  - osx
+#  - windows
+
+node_js:
+  - node
+
+stages:
+  - lint
+  - unit
+  - test
+  - deploy
+
+jobs:
+  include:
+  - stage: lint
+    script: npm run lint
+  - stage: unit
+    script: npm run test:unit
+  - stage: test
+    script: npx xvfb-maybe npm run test-start
+  - stage: deploy
+    if: tag IS present
+    os: linux
+    services: docker
+    language: generic
+
+    script:
+      - |
+        docker run --rm \
+        -v ${PWD}:/project \
+        -v ~/.cache/electron:/root/.cache/electron \
+        -v ~/.cache/electron-builder:/root/.cache/electron-builder \
+        -v ~/dist_electron/:/root/dist_electron \
+        electronuserland/builder:wine \
+        /bin/bash -c "npm ci && npm run electron:generate-icons && npx vue-cli-service electron:build --config electron-builder.json --publish never -lw"
+
+cache:
+  npm: true
+  directories:
+    - $HOME/.cache/electron
+    - $HOME/.cache/electron-builder
+
+before_cache:
+  - rm -rf $HOME/.cache/electron-builder/wine
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: "$GITHUB_TOKEN"
+  file_glob: true
+  file:
+  - dist_electron/*.AppImage
+  - dist_electron/*.exe
+  on:
+    tags: true
+    stage: deploy
+    branch: master
+
+env:
+  global:
+    secure: cpyX4rAxApGy7c20ZInazQDKXpUgpmUcN6jWJGHxWxEbvYHEPrnBTjEapSHrYB/Q9Svwku045rV7HTxlGNSlt985ejJ+QHRd7qofc8EDmwTXGysAx/XVbWP9fBF96H27ErBlNq3Sd2ct26zubRmJd7Mpv73E3ndFl/BvO/d8BuUv8WET6a2/uRRrPuJVpCc9zOe3/5paPsG4bIcxQhzSzpLnrQG9IzCXi/5s3xCYr07/rp8BI6ojwTpQ/aUOtd5how7EzM3Ce0CREZxTjN33IH47j8DZLl1f4MhzPTtxtdeKUEEelqy67EErfb2Jcf0u098QtWSG/Sp+0dZOZm4IiiLBs+qqw1sXGgVGieq5AFmq70yZ3CyD1aIKukYVJxbDSK55kjMnheDmdCdass4+LRQ4VezdfrYXlQ2zM4/y3xympAn2ysfDb4XxbvcicvPEiPumtwVfr3WPbLGGqlb69rVJwna4MzefySDXzU15fbVs62iQyB6TLlA0aUNjPI3ocxTNkeR0Yu0WvQDsr6D9RZsHyq7SjtUiDHfJxE4KXSRTjsYUICueOCDQBDUxXIqPEDg9dZSEP0Nt6fa7940DryqJ93QZl8IwRgKPkB7A//XmCnKBE6yq9F1SWwxNuDEHzj5MF4y+XYWjT8+r3xXvo6G45LqFOwlhP4SvepNhZNo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,18 @@ jobs:
         electronuserland/builder:wine \
         /bin/bash -c "npm ci && npm run electron:generate-icons && npx vue-cli-service electron:build --config electron-builder.json --publish never -lw"
 
+  - stage: deploy
+    if: tag IS present
+    os: osx
+    osx_image: xcode10.2
+    env:
+      - ELECTRON_CACHE=$HOME/.cache/electron
+      - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
+    language: node_js
+    node_js: node
+    script: npm ci && npm run electron:generate-icons && npx vue-cli-service electron:build --config electron-builder.json --publish never -m
+
 cache:
   npm: true
   directories:
@@ -55,6 +67,7 @@ deploy:
   file:
   - dist_electron/*.AppImage
   - dist_electron/*.exe
+  - dist_electron/*.dmg
   on:
     tags: true
     stage: deploy

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Waterproof is an educational tool in which students can interactively prove mathematical statements. Here is an example of an exercise and part of its solution in Waterproof.
 
+Develop build status: [![Build Status](https://travis-ci.org/impermeable/waterproof.svg?branch=develop)](https://travis-ci.org/impermeable/waterproof)
+
 ![Screenshot of waterproof](WaterproofScreenshot.png)
 
 ## How to get started

--- a/package-lock.json
+++ b/package-lock.json
@@ -5066,6 +5066,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chai-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
     "cross-env": "^5.2.0",
     "electron-debug": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "doc": "jsdoc src -r -d doc",
     "lint": "vue-cli-service lint",
-    "test": "vue-cli-service test:unit",
-    "test-e2e": "mocha \"tests/e2e/*.e2e.js\"",
-    "electron:build": "vue-cli-service electron:build --config electron-builder.json",
+    "test:unit": "vue-cli-service test:unit",
+    "test-start": "mocha \"tests/e2e/*.e2e.js\" --timeout 100000 --bail",
+    "electron:build": "vue-cli-service electron:build --config electron-builder.json --publish never",
     "electron:serve": "vue-cli-service electron:serve",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@gitlab.tue.nl:ChefCoq/waterproof.git"
+    "url": "git@github.com:impermeable/waterproof.git"
   },
   "keywords": [
     "coq",

--- a/tests/e2e/electron.e2e.js
+++ b/tests/e2e/electron.e2e.js
@@ -8,7 +8,7 @@ chai.use(chaiAsPromised);
 
 describe('Application launch', function() {
   // eslint-disable-next-line no-invalid-this
-  this.timeout(30000);
+  this.timeout(60000);
 
   let app;
   let stopServe;


### PR DESCRIPTION
Includes:
- linting run
- unit test run
- test if application starts on all platforms (only linux right now)
- will build the application on a tag and upload the AppImage and exe installer to github.

Current issues:
- no start test on windows and mac
- no building off mac application