### PR TITLE
Execution error feedback shortened

### DIFF
--- a/src/editpage/components/ProofWindow.vue
+++ b/src/editpage/components/ProofWindow.vue
@@ -296,7 +296,13 @@ export default {
           };
         }
         if (blockEnd >= errorEndIndex) {
-          block.state.error.message = error;
+          if (/In environment[\s\S]*Unable to unify /.test(error)) {
+            block.state.error.message =
+                error.replace(/In environment[\s\S]*Unable to unify /,
+                    'Unable to unify ');
+          } else {
+            block.state.error.message = error;
+          }
           break;
         }
         index += block.text.length + 1;

--- a/src/editpage/components/ProofWindow.vue
+++ b/src/editpage/components/ProofWindow.vue
@@ -296,13 +296,12 @@ export default {
           };
         }
         if (blockEnd >= errorEndIndex) {
-          if (/In environment[\s\S]*Unable to unify /.test(error)) {
-            block.state.error.message =
-                error.replace(/In environment[\s\S]*Unable to unify /,
-                    'Unable to unify ');
-          } else {
-            block.state.error.message = error;
+          const longError =
+              error.match(/In environment[\s\S]*Unable to unify([\s\S]*)$/);
+          if (longError != null) {
+            error = 'Unable to unify ' + longError[1];
           }
+          block.state.error.message = error;
           break;
         }
         index += block.text.length + 1;


### PR DESCRIPTION
If 'In environment ... Unable to unify ....' , Then, remove the part before 'Unable to unify'