### PR TITLE
Fix initial whitespaces & don't remove the final .

### DIFF
--- a/src/editpage/components/blocks/code/CodeBlock.vue
+++ b/src/editpage/components/blocks/code/CodeBlock.vue
@@ -36,7 +36,9 @@ export default {
   mixins: [WpBlock],
   computed: {
     formattedText: function() {
-      const text = this.block.text.trim();
+      const whitespaceLength = this.block.text.length
+          - this.block.text.trimStart().length;
+      const text = this.block.text.trimEnd();
 
       // Determine where to insert error, tick, or both
       const splitAt = this.foundSentences.map((i) => {
@@ -56,7 +58,7 @@ export default {
       const parts = [];
       // Sort from last to first
       splitAt.sort((obj1, obj2) => obj1.at - obj2.at);
-      let index = 0;
+      let index = whitespaceLength; // Instead of starting at 0.
       let inError = false;
       for (const obj of splitAt) {
         const newIndex = obj.at;
@@ -76,12 +78,8 @@ export default {
           let type = '';
           if (realIndex === this.executedIndex) {
             type = 'done';
-            // skip a character (the final .)
-            index++;
           } else if (realIndex === this.runningIndex) {
             type = 'doing';
-            // skip a character (the final .)
-            index++;
           }
 
           parts.push({


### PR DESCRIPTION
1) No longer removing the `.` (or `-` in a split). Note: may still want to append `' '` instead of writing over the `.` or `-`, but we'll discuss this.

2) To remove the initial whitespaces was a bit tricky, because setting `const text` (line 40-ish) to the trimmed text was problematic. I found it hard to know in which places we needed to account for the offset in sentence-end index, as simply removing the number of whitespaces from `splitAt.at` or `realIndex` gave errors in another place that couldn't match the sentence-end's. Rather, I opted to leave the indices, and just skip the drawing of the initial whitespaces by setting `index=whitespaceLength`. I believe this doesn't cause any problems in other places @davidot ?