### PR TITLE
moved error below messages and added auto-scroll on error message pop-up

### DIFF
--- a/src/editpage/components/response/MessagesWindow.vue
+++ b/src/editpage/components/response/MessagesWindow.vue
@@ -9,12 +9,6 @@
         </div>
         <div class="messages" v-if="ready"
              ref="messagesBox">
-            <div class="message message-error"
-                 v-if="haveAddError && showingAddError">
-                <span class="messageText">
-                    {{addErrorText}}
-                </span>
-            </div>
             <div class="message highlight"
                  style="animation-name: blinkColors;"
                  @animationend="removeAnimation"
@@ -29,6 +23,12 @@
                     <div class="clear-message"></div>
                 </a>
             </div>
+            <div class="message message-error"
+               v-if="haveAddError && showingAddError" ref="addErrorElement">
+                <span class="messageText">
+                    {{addErrorText}}
+                </span>
+          </div>
         </div>
         <div style="text-align: center" v-else>
             <span>
@@ -180,6 +180,16 @@ export default {
           error: this.addError.message,
           file: this.addError.file,
         });
+        if (typeof(requestAnimationFrame) !== 'undefined') {
+          if (this.showingAddError) {
+            requestAnimationFrame(() => {
+              this.$refs.addErrorElement.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+              });
+            });
+          }
+        }
       }
     },
   },


### PR DESCRIPTION
After testing it out this seems to scroll always when the error messages pop-up, but sometimes not automatically (with some delay)