### PR TITLE
added whitespace to emphasize goals

### DIFF
--- a/src/editpage/components/response/Goal.vue
+++ b/src/editpage/components/response/Goal.vue
@@ -79,7 +79,8 @@ export default {
     },
     subGoal: function() {
       if (this.parts.length > 1) {
-        return this.parts[1].trim().replace(/\n/g, '<br>');
+        return this.parts[1].trim().replace(
+            /\n/g, '<br>').replace(/<br> {2}/g, '<br>&emsp;&nbsp;');
       }
     },
     showHypotheses: function() {

--- a/src/editpage/components/response/Goal.vue
+++ b/src/editpage/components/response/Goal.vue
@@ -11,8 +11,13 @@
     <div class="hrfake">
       <span class="goal-id">({{index + 1}}/{{total}})</span>
     </div>
-    <div :class="{opened: opened, 'opened-tick': true}">▶</div>
-    <span class="goal-target" v-html="subGoal"></span>
+    <div v-if="showHypotheses" :class="{opened: opened, 'opened-tick': true}">
+      ▶
+    </div>
+    <span :class="{'goal-target': true,
+      'goal-with-hypotheses': showHypotheses}"
+          v-html="subGoal">
+    </span>
   </div>
 </template>
 
@@ -172,9 +177,12 @@ export default {
     margin-bottom: -1.3em;
   }
 
-  .goal-target {
+  .goal-with-hypotheses {
     margin-top: 0.3em;
     margin-left: 1em;
   }
 
+  .goal-target {
+    margin-top: 0.3em;
+  }
 </style>


### PR DESCRIPTION
From Coq's side, to emphasize lines they are sent with 2 (or more) whites paces before the line (so right after the <br>).

If we just force html to show those white spaces, which can be done by adding ```white-space: pre;``` to the class of the html object, we get some of the lines with too much indentation (because they have more than 2 white spaces).

Replacing the white space with  ```&emsp;&nbsp;``` has all of them showing the same amount of indentation (5 spaces).