### PR TITLE
Changed indentation at goal window from using &nbsp to normal whitespaces

### DIFF
--- a/src/editpage/components/response/Goal.vue
+++ b/src/editpage/components/response/Goal.vue
@@ -84,8 +84,13 @@ export default {
     },
     subGoal: function() {
       if (this.parts.length > 1) {
-        return this.parts[1].trim().replace(
-            /\n/g, '<br>').replace(/<br> {2}/g, '<br>&emsp;&nbsp;');
+        let goalString = this.parts[1].trim().replace(/\n/g, '<br>');
+        if (goalString.search(/<br> {31}/g) !== -1) {
+          goalString = goalString.replace(/<br> {31}/g, '<br>     ');
+        } else if (goalString.search(/<br> {2}/g) !== -1) {
+          goalString = goalString.replace(/<br> {2}/g, '<br>     ');
+        }
+        return goalString;
       }
     },
     showHypotheses: function() {
@@ -180,9 +185,11 @@ export default {
   .goal-with-hypotheses {
     margin-top: 0.3em;
     margin-left: 1em;
+    white-space: break-spaces;
   }
 
   .goal-target {
     margin-top: 0.3em;
+    white-space: break-spaces;
   }
 </style>


### PR DESCRIPTION
Using &nbsp to show white spaces in the goal window makes it so that text copied from the goal window is not accepted by waterproof if added as part of an exercise (this is needed when rewriting goals using "that is..." type expressions).

Now the html shows all the indentation white spaces, which come in two forms:
- indentation of just 2 white spaces
- indentation of 31 white spaces, which can be followed by consecutive lines of 31+1, 31+2,... white spaces.

These two cases are both handled and shorted down to an indentation of 6 white spaces, with the the 31+1,31+2 etc... cases having 6+1,6+2... white spaces as indentation (for stair-case type messages).
