### PR TITLE
Run coq commands in isolation

### DIFF
--- a/src/coq/serapi/processors/SerapiSearchProcessor.js
+++ b/src/coq/serapi/processors/SerapiSearchProcessor.js
@@ -2,7 +2,7 @@ import SerapiProcessor from '../util/SerapiProcessor';
 import {Mutex} from 'async-mutex';
 import {
   createCheckCommand, createQueryVernacCommand,
-  createSearchCommand,
+  createIndexedQueryVernacCommand, createSearchCommand,
 } from '../util/SerapiCommandFactory';
 import {COQ_EXCEPTION, parseErrorResponse} from '../SerapiParser';
 
@@ -217,20 +217,41 @@ class SerapiSearchProcessor extends SerapiProcessor {
    * @private
    */
   async _queryCommand(command) {
-    return this.sendCommand(createQueryVernacCommand(command), 'raw',
-        (feedback) => {
-          return {
-            result: feedback.string,
-          };
-        })
-        .then((result) => {
-          if (result.hasOwnProperty('result')) {
-            this.editor.message(result.result);
-          }
-          if (result.error) {
-            this.editor.message(result.errorMessage);
-          }
-        });
+    try {
+      return this.sendCommand(
+          createIndexedQueryVernacCommand(
+              command, this.state.idOfSentence(this.state.lastExecuted)), 'raw',
+          (feedback) => {
+            return {
+              result: feedback.string,
+            };
+          })
+          .then((result) => {
+            if (result.hasOwnProperty('result')) {
+              this.editor.message(result.result);
+            }
+            if (result.error) {
+              this.editor.message(result.errorMessage);
+            }
+          });
+    } catch (e) {
+      return this.sendCommand(
+          createQueryVernacCommand(
+              command), 'raw',
+          (feedback) => {
+            return {
+              result: feedback.string,
+            };
+          })
+          .then((result) => {
+            if (result.hasOwnProperty('result')) {
+              this.editor.message(result.result);
+            }
+            if (result.error) {
+              this.editor.message(result.errorMessage);
+            }
+          });
+    }
   }
 
   /**

--- a/src/coq/serapi/util/SerapiCommandFactory.js
+++ b/src/coq/serapi/util/SerapiCommandFactory.js
@@ -69,6 +69,18 @@ export function createQueryVernacCommand(command) {
 }
 
 /**
+ * Partial method for vernac commands to execute the command
+ * after a specific sentece
+ * @param {String} command the vernac commmand to execute
+ * @param {number} sentenceId the sentence id after which
+ * the command should execute
+ * @return {string} the command
+ */
+export function createIndexedQueryVernacCommand(command, sentenceId) {
+  return `(Query ((sid ${sentenceId})) (Vernac "${sanitise(command)}"))`;
+}
+
+/**
  * Create a serapi check command
  * @param {String} query the term to check for
  * @return {string} the command


### PR DESCRIPTION
Added method for querying vernac commands where the sentenceID to query from can be chosen. In addition, used this method to implemented running isolated coq commands (where chosen sentenceID = last run sentenceID).

These isolated coq commands can be run from the assistance bar.

Further down the line, a different menu to run these isolated commands might be implemented, so we should wait to merge the branch until that is decided.